### PR TITLE
Replace MySQL Python client library

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # Isolating Django from the other requirements allows better cross-version
 # (Django) testing.
 
-MySQL-python==1.2.5
+mysqlclient==1.4.6                      # MySQL client, version 2 will drop Python 2 support
 pysolr>=3.3.0,<3.4.0
 
 pytz>=2014,<2015

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     flake8,
     deployed,
-    py27-django{1.9,1.8,1.7}
+    py27-django{1.11}
+    py36-django{1.11}
 
 [testenv]
 setenv =
@@ -12,11 +13,15 @@ basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 deps =
     django1.7: Django>=1.7,<1.8
     django1.8: Django>=1.8,<1.9
     django1.9: Django>=1.9,<1.10
-    django1.10: Django==1.9a1
+    django1.11: Django>=1.11,<2
+    django2: Django>=2,<2.1
+    django2.1: Django>=2.1,<2.2
+    django2.2: Django>=2.2,<3
     -r{toxinidir}/requirements/base.txt
 
 [testenv:deployed]


### PR DESCRIPTION
The currently specified `MySQL-Python` library is out of date, only supporting MySQL versions up to 5.5 and without any Python 3 support. The library has not been updated since 2014!

The `mysqlclient` library supports a much broader range of MySQL versions and the version specified below supports both Python 2.7 and Python 3.