### PR TITLE
Add documentation for custom deployment

### DIFF
--- a/deployment/roles/covid_library/files/_local_settings.py
+++ b/deployment/roles/covid_library/files/_local_settings.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+"""
+Local settings for django-covid
+
+This is an example of config/local_settings.py
+
+"""
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# TODO: CHANGE ME!
+SECRET_KEY = '1h*u)(+!m_4dj=eea5i!6od+ic9o+u3tg_1y26myy)t+qt5ta='
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+
+# TODO: CHANGE ME!
+ALLOWED_HOSTS = ['*']
+
+
+# TODO: CHANGE ME!
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'name',
+        'USER': 'user',
+        'PASSWORD': 'password',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+
+
+LANGUAGE_CODE = 'en-us'
+gettext = lambda s: s
+LANGUAGES = [
+    ('en', u'English'),
+]
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+SITE_ID = 1
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.8/howto/static-files/
+
+# Absolute filesystem path to the directory that will hold user-uploaded files.
+# Example: "/var/www/example.com/media/"
+# TODO change me IF on a custom deployment
+MEDIA_ROOT = '/home/www/platform/media/'
+
+# URL that handles the media served from MEDIA_ROOT. Make sure to use a
+# trailing slash.
+# Examples: "http://example.com/media/", "http://media.example.com/"
+MEDIA_URL = '/media/'
+
+# Absolute path to the directory static files should be collected to.
+# Don't put anything in this directory yourself; store your static files
+# in apps' "static/" subdirectories and in STATICFILES_DIRS.
+# Example: "/var/www/example.com/static/"
+# TODO change me IF on a custom deployment
+STATIC_ROOT = '/home/www/platform/static/'
+
+# URL prefix for static files.
+# Example: "http://example.com/static/", "http://static.example.com/"
+STATIC_URL = '/static/'
+
+# TODO: CHANGE ME!
+SERVER_EMAIL = 'Covid Library <info@yourdomain.com>'
+# TODO: CHANGE ME!
+EMAIL_SUBJECT_PREFIX = '[COVIDLIBRARY]: '
+# TODO: CHANGE ME!
+ADMINS = (
+    ('Your Name', 'you@yourdomain.com'),
+)
+

--- a/deployment/roles/covid_library/files/covid-library-ssl.conf
+++ b/deployment/roles/covid_library/files/covid-library-ssl.conf
@@ -1,0 +1,44 @@
+<VirtualHost *:443>
+	SSLEngine On
+
+	ServerName my-covid-library.com
+	WSGIDaemonProcess localhost.libraryssl python-path=/home/www/platform/django-covid:/home/www/platform/env:/home/www/platform/env/lib/python3.6/site-packages
+	WSGIProcessGroup localhost.libraryssl
+	WSGIScriptAlias / /home/www/platform/django-covid/config/wsgi.py
+	WSGIPassAuthorization On
+
+	<Directory /home/www/platform/>
+		Require all granted
+	</Directory>
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /home/www/platform/
+
+	ErrorLog /var/log/apache2/orb-error.log
+
+	# Possible values include: debug, info, notice, warn, error, crit,
+	# alert, emerg.
+	LogLevel warn
+
+	CustomLog /var/log/apache2/orb-access.log combined
+
+	Alias /media /home/www/platform/media/
+	<Directory "/home/www/platform/media/">
+		Options MultiViews FollowSymLinks
+		AllowOverride None
+		Require all granted
+	</Directory>
+
+	Alias /static /home/www/platform/static/
+	<Directory "/home/www/platform/static/">
+		Options MultiViews FollowSymLinks
+		AllowOverride None
+		Require all granted
+	</Directory>
+
+# These lines are otherwise left out and populated solely by Let's Encrypt
+SSLCertificateFile /etc/letsencrypt/live/my-covid-library.com/fullchain.pem
+SSLCertificateKeyFile /etc/letsencrypt/live/my-covid-library.com/privkey.pem
+Include /etc/letsencrypt/options-ssl-apache.conf
+
+</VirtualHost>

--- a/deployment/roles/covid_library/files/covid-library.conf
+++ b/deployment/roles/covid_library/files/covid-library.conf
@@ -1,0 +1,38 @@
+<VirtualHost *:80>
+
+	ServerName my-covid-library.com
+	WSGIDaemonProcess localhost.library python-path=/home/www/platform/django-covid:/home/www/platform/env/lib/python3.6/site-packages
+	WSGIProcessGroup localhost.library
+	WSGIScriptAlias / /home/www/platform/django-covid/config/wsgi.py
+	WSGIPassAuthorization On
+
+	<Directory /home/www/platform/>
+		Require all granted
+	</Directory>
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /home/www/platform/
+
+	ErrorLog /var/log/apache2/orb-error.log
+
+	# Possible values include: debug, info, notice, warn, error, crit,
+	# alert, emerg.
+	LogLevel warn
+
+	CustomLog /var/log/apache2/orb-access.log combined
+
+	Alias /media /home/www/platform/media/
+	<Directory "/home/www/platform/media/">
+		Options MultiViews FollowSymLinks
+		AllowOverride None
+		Require all granted
+	</Directory>
+
+	Alias /static /home/www/platform/static/
+	<Directory "/home/www/platform/static/">
+		Options MultiViews FollowSymLinks
+		AllowOverride None
+		Require all granted
+	</Directory>
+
+</VirtualHost>

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -91,3 +91,52 @@ source controlled settings. By doing so it may override the base settings or add
 You should go through this file and address the items commented for your attention, including
 the Django "secret key" (you can change to arbitrarily random text), various email addresses,
 and the allowed host names.
+
+Deploying to an existing server
+===============================
+
+The Covid Library application can be deployed to an existing server or using a
+custom configuration. The AMI ships with the following software versions,
+and while other versions will likely work just as well, they have not been
+tested.
+
+- Ubuntu 16.04 LTS
+- Apache 2.4
+- Python 3.6
+- libapache2-mod-wsgi-py3 4.3
+- MySQL 5.7
+- Solr 4.10
+
+The only hard requirement for custom deployments is that you use Python 3.6.
+
+Alternative combinations could use `Gunicorn <https://gunicorn.org/>`_ proxied behind
+`Nginx <https://nginx.org/>`_, use PostgreSQL (not tested, but there are no MySQL
+specific features used by the library), and use a different Solr version or search
+engine altogether. The latter may be appealing given that the version of Solr here
+is not current, however changing the Solr version or search engine would require
+changes to the search engine index templates.
+
+At a high level, the outline of the steps for installing and running on a separate
+server would look like the following:
+
+1. Establish an application project directory
+2. In this directory clone the project Git repository into `django-covid`
+3. Create a Python virtual environment named `env` here, `python3.6 -m virtualenv env --python=$(which python3.6)`
+   (specifying the Python path using the `--path` option ensures the correct Python version for the environment)
+4. Active the virtual environment and install the requirements (`source env/bin/activate && cd django-covid && pip install -r requirements.txt`)
+5. Add a local settings file in `django-covid/config/local_settings.py` and use this to override
+   project specific settings such as `DATABASES`, `SECRET_KEY`, etc. A sample can be found in
+   the `deployment/` directory. You will need to set up media and static file directories,
+   respectively, and ensure that your application's system user has read and write access to these
+   directories and that they are mapped in your webserver host configuration (again, refer to
+   the included Ansible Apache host templates here).
+6. Either install `mod_wsgi` and enable in Apache and follow the WSGI settings in the Ansible
+   templates here OR set up a different application server. If you are using Nginx then Gunicorn
+   or `uWSGI <https://uwsgi-docs.readthedocs.io/en/latest/>`_ are good choices for serving the
+   Django application. Setting these up is beyond the scope of these docs.
+7. You will need to migrate your database using the `python manage.py migrate` command from the
+   application root (i.e. the cloned repository) and collect static files from various installed
+   Django apps (e.g. the core `orb` installation itself, the Django admin app, etc) into your
+   configured static files directory (`python manage.py collectstatic --noinput`)
+
+


### PR DESCRIPTION
This adds some documentation including illustrative helper files for getting started with a deployment in a custom server environment.